### PR TITLE
Revert "Fix schnieder eqn 16"

### DIFF
--- a/cpw.py
+++ b/cpw.py
@@ -271,7 +271,7 @@ def R_rad(w,s,wg,t,f,er):
     r1 = a/b
     r2 = np.sqrt((c**2-b**2)/(c**2-a**2))
     r = r1*r2
-    return mu0**3*ep0**2*omega**5/16/er*(er-erq)**3*(np.sqrt(8)-2.75)*( (b**2-a**2)*(K(np.sqrt(r))-PI(r1,r)-PI(r2,r))/K(np.sqrt(r)) )**2
+    return mu0**3*ep0**2*omega**5/16/er*(er-erq)**3*(np.sqrt(8)-2.75)*( (b**2-a**2)*(K(r)-PI(r1,r)-PI(r2,r))/K(r) )**2
 
 
 def get_all_paras(x, cpw):

--- a/cpw.py
+++ b/cpw.py
@@ -271,7 +271,7 @@ def R_rad(w,s,wg,t,f,er):
     r1 = a/b
     r2 = np.sqrt((c**2-b**2)/(c**2-a**2))
     r = r1*r2
-    return mu0**3*ep0**2*omega**5/16/er*(er-erq)**3*(np.sqrt(8)-2.75)*( (b**2-a**2)*(K(r)-PI(r1,r)-PI(r2,r))/K(r) )**2
+    return mu0**3*ep0**2*omega**5/16/er*(er-erq)**3*(np.sqrt(8)-2.75)*( (b**2-a**2)*(K(r)-PI(r1**2,r**2)-PI(r2**2,r**2))/K(r) )**2
 
 
 def get_all_paras(x, cpw):


### PR DESCRIPTION
Reverts ZiadHatab/transmission-line-models#11

I assumed that `r = m = k^2`. This was wrong. It's `r^2 = m = k^2`. In the mean time I've the Schnieder FORTRAN code and I double checked that.

So it should be `K(r)-PI(r1**2,r**2)-PI(r2**2,r**2))/K(r)` instead of `K(r)-PI(r1,r)-PI(r2,r))/K(r)` because your `K` function has `k` as parameter and your `PI` based on the Carlson integrals has `n` and `m` as input parameters. Therefor the input arguments `r1`, `r2` and `r` need to be squared for the `PI`function.

Sorry for the confutation.